### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,8 +6,10 @@ For Redmine versions prior to 2.x, check out the pre-2.x branch.
 
 = Installation
 
+The usual {installation instructions}[http://www.redmine.org/projects/redmine/wiki/Plugins]
+for Redmine plugins apply. The (very brief) summary:
 Download or git clone to the plugins directory, run `rake
-db:migrate:plugins` to create database tables.
+redmine:plugins:migrate` to create database tables.
 
 Enable the 'Canned Responses' module for projects you need this
 feature in.


### PR DESCRIPTION
This changes the migration command to work with 2.x (was for 1.x),
and also adds a reference to the usual installation instructions
for Redmine plugins.
