### PR TITLE
Admin access to global canned responses

### DIFF
--- a/app/helpers/canned_responses_helper.rb
+++ b/app/helpers/canned_responses_helper.rb
@@ -1,4 +1,12 @@
 module CannedResponsesHelper
+  def authorize_for(controller, action)
+    User.current.allowed_to?({:controller => controller, :action => action}, @project)
+  end
+
+  def link_to_if_authorized(name, options = {}, html_options = nil, *parameters_for_method_reference)
+    link_to(name, options, html_options, *parameters_for_method_reference) if authorize_for(options[:controller] || params[:controller], options[:action])
+  end
+
   def edit_canned_response_link(canned_response, title = l(:button_edit))
     link_to_if_authorized(title,
                           { :controller => "canned_responses", :action => "edit",

--- a/app/helpers/canned_responses_helper.rb
+++ b/app/helpers/canned_responses_helper.rb
@@ -1,8 +1,11 @@
 module CannedResponsesHelper
+  # HACK: Override authorize_for to enable admins to manage canned responses.
   def authorize_for(controller, action)
     User.current.allowed_to?({:controller => controller, :action => action}, @project, :global => true)
   end
 
+  # HACK: Override link_to_if_authorized so that we can use a custom
+  # authorize_for which enables admins to manage canned responses.
   def link_to_if_authorized(name, options = {}, html_options = nil, *parameters_for_method_reference)
     link_to(name, options, html_options, *parameters_for_method_reference) if authorize_for(options[:controller] || params[:controller], options[:action])
   end

--- a/app/helpers/canned_responses_helper.rb
+++ b/app/helpers/canned_responses_helper.rb
@@ -1,6 +1,6 @@
 module CannedResponsesHelper
   def authorize_for(controller, action)
-    User.current.allowed_to?({:controller => controller, :action => action}, @project)
+    User.current.allowed_to?({:controller => controller, :action => action}, @project, :global => true)
   end
 
   def link_to_if_authorized(name, options = {}, html_options = nil, *parameters_for_method_reference)

--- a/app/views/hooks/_canned_responses_issue_insert.html.erb
+++ b/app/views/hooks/_canned_responses_issue_insert.html.erb
@@ -1,6 +1,6 @@
 <p>
 <% options = canned_response_options_for_select %>
-  <% if options.present? and User.current.allowed_to?(:use_canned_responses, @project) %>
+  <% if options.present? and User.current.allowed_to?(:use_canned_responses, @project, :global => true) %>
     <%= label_tag :canned_response, l(:label_insert_canned_response) %>
     <% url = url_for(:controller => 'canned_responses', :action => 'insert',
                      :project_id => nil, :id => ':id') %>
@@ -17,7 +17,7 @@ EOF
         :onchange => js %>
 <% end %>
 
-<% if User.current.allowed_to? :manage_canned_responses, @project %>
+<% if User.current.allowed_to? :manage_canned_responses, @project, :global => true %>
   <br/>
   <%= link_to l(:label_manage_canned_responses),
       url_to_canned_responses_settings_tab %>

--- a/lib/redmine_canned_responses/projects_helper_patch.rb
+++ b/lib/redmine_canned_responses/projects_helper_patch.rb
@@ -10,7 +10,7 @@ module RedmineCannedResponses
     
     def project_settings_tabs_with_canned_responses
       project_settings_tabs_without_canned_responses.tap do |tabs|
-        if User.current.allowed_to?(:manage_canned_responses, @project)
+        if User.current.allowed_to?(:manage_canned_responses, @project, :global => true)
           tabs.push({ :name => 'canned_responses',
                       :action => :manage_project_canned_responses,
                       :partial => 'canned_responses/project_settings',


### PR DESCRIPTION
This pull request enables admins to manage the global canned responses without having to manually enter the correct URLs for doing so. It works by setting :global=>true when invoking allowed_to?. Unfortunately, this does not work for link_to_if_authorized, so I have to override that and also authorize_for.

I know you might not be interested in merging this and instead want upstream to fix this, but for the pragmatic, this is at least a proof-of-concept on how to get this working for now.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/commandprompt/redmine_canned_responses/16)

<!-- Reviewable:end -->
